### PR TITLE
Fix Error in Countdown Timer

### DIFF
--- a/src/components/UI/Timer.jsx
+++ b/src/components/UI/Timer.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 
-const Timer = () => {
+const Timer = ({expiryDate}) => {
   const [timeLeft, setTimeLeft] = useState({
     hours: 0,
     minutes: 0,
     seconds: 0,
   });
-  let time = Math.floor(Math.random() * 21600);
+  let time = (expiryDate-Date.now())/1000
   const countdown = () => {
     if (time >= 0) {
       const seconds = Math.floor(time % 60);

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -86,8 +86,8 @@ const NewItems = () => {
                             />
                             <i className="fa fa-check"></i>
                           </Link>
-                      </div>
-                      <Timer />
+                        </div>
+                        <Timer expiryDate={newItem.expiryDate} />
                         <div className="nft__item_wrap">
                           <div className="nft__item_extra">
                             <div className="nft__item_buttons">
@@ -106,7 +106,6 @@ const NewItems = () => {
                               </div>
                             </div>
                           </div>
-
                           <Link to={`/item-details/${newItem.nftId}`}>
                             <img
                               src={newItem.nftImage}


### PR DESCRIPTION
**This PR fixes an error found in the countdown timer of each of the items in the New Items carousel.**

- Each timer now makes use of the item's expiryDate attribute rather than a random number generator when calculating the time left before expiry.

**Screenshot:**

<img width="1790" height="855" alt="image" src="https://github.com/user-attachments/assets/2058cef1-6cab-48ab-b026-0c5e9c2b4ad7" />